### PR TITLE
[TECH] Add node, mocha and some rules to eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,8 @@
 /*eslint-env node*/
 module.exports = {
-  "parserOptions": {
-    "ecmaVersion": 6,
-    "sourceType": "module"
+  'parserOptions': {
+    'ecmaVersion': 6,
+    'sourceType': 'module'
   },
   'globals': {
     'accounting': true,
@@ -19,7 +19,9 @@ module.exports = {
   'env': {
     'browser': true,
     'amd': true,
-    'jquery': true
+    'jquery': true,
+    'node': true,
+    'mocha': true
   },
   'rules': {
     'camelcase': 2,
@@ -41,6 +43,12 @@ module.exports = {
     'no-underscore-dangle': 0,
     'no-void': 2,
     'quotes': [2, 'single'],
-    'semi': [2, 'always']
+    'semi': [2, 'always'],
+    'keyword-spacing': ['error', { 'before': true, 'after': true}],
+    'space-before-blocks': 2,
+    'space-infix-ops': 2,
+    'padded-blocks': ['error', 'never'],
+    'space-in-parens': 2,
+    'comma-spacing': [2, { 'before': false, 'after': true }]
   }
 };


### PR DESCRIPTION
Add node and mocha config and the rules below.

[  **keyword-spacing**](https://eslint.org/docs/rules/keyword-spacing.html)
"before": true (default) requires at least one space before keywords
"after": true (default) requires at least one space after keywords

Examples of incorrect code for this rule with the default { "before": true } option:
```
/*eslint keyword-spacing: ["error", { "before": true }]*/

if (foo) {
    //...
}else {
    //...
}
```
Example of correct code for this rule with the default { "before": true } option:
```
/*eslint keyword-spacing: ["error", { "before": true }]*/

if (foo) {
    //...
} else {
    //...
}
```

Examples of incorrect code for this rule with the default { "after": true } option:
```
/*eslint keyword-spacing: ["error", { "after": true }]*/

if(foo) {
    //...
} else{
    //...
}
```
Example of correct code for this rule with the default { "after": true } option:
```
/*eslint keyword-spacing: ["error", { "after": true }]*/

if (foo) {
    //...
} else {
    //...
}
```
[**space-before-blocks**](https://eslint.org/docs/rules/space-before-blocks.html)
Example of incorrect code for this rule with the “always” option:
```
/*eslint space-before-blocks: "error"*/

if (a){
    b();
}
```
Example of correct code for this rule with the “always” option:
```
/*eslint space-before-blocks: "error"*/

if (a) {
    b();
}
```
[**space-infix-ops**](https://eslint.org/docs/rules/space-infix-ops.html)
Examples of incorrect code for this rule:
```
/*eslint space-infix-ops: "error"*/

a+b

a?b:c

function foo(a=0) { }
```
Examples of correct code for this rule:
```
/*eslint space-infix-ops: "error"*/

a + b

a ? b : c

function foo(a = 0) { }
```
[**padded-blocks**](https://eslint.org/docs/rules/padded-blocks.html)
"never" disallows empty lines at the beginning and ending of block statements and classes
Examples of incorrect code for this rule with the "never" option:
```
/*eslint padded-blocks: ["error", "never"]*/

if (a) {

    b();

}

if (a)
{

    b();

}

if (a) {

    b();
}

if (a) {
    b();

}
```
Examples of correct code for this rule with the "never" option:
```
/*eslint padded-blocks: ["error", "never"]*/

if (a) {
    b();
}

if (a)
{
    b();
}
```

[**space-in-parens**](https://eslint.org/docs/rules/space-in-parens.html)
Examples of incorrect code for this rule with the default "never" option:
```
/*eslint space-in-parens: ["error", "never"]*/

foo( 'bar');
foo('bar' );
foo( 'bar' );

var foo = ( 1 + 2 ) * 3;
( function () { return 'bar'; }() );
```
Examples of correct code for this rule with the default "never" option:
```
/*eslint space-in-parens: ["error", "never"]*/

foo();

foo('bar');

var foo = (1 + 2) * 3;
(function () { return 'bar'; }());
```
[**comma-spacing**](https://eslint.org/docs/rules/comma-spacing)
"before": false (default) disallows spaces before commas
"after": true (default) requires one or more spaces after commas

Examples of incorrect code for this rule with the default { "before": false, "after": true } options:
```
/*eslint comma-spacing: ["error", { "before": false, "after": true }]*/

var foo = 1 ,bar = 2;
var arr = [1 , 2];
var obj = {"foo": "bar" ,"baz": "qur"};
foo(a ,b);
new Foo(a ,b);
function foo(a ,b){}
a ,b
```
Examples of correct code for this rule with the default { "before": false, "after": true } options:
```
/*eslint comma-spacing: ["error", { "before": false, "after": true }]*/

var foo = 1, bar = 2
    , baz = 3;
var arr = [1, 2];
var arr = [1,, 3]
var obj = {"foo": "bar", "baz": "qur"};
foo(a, b);
new Foo(a, b);
function foo(a, b){}
a, b
```
